### PR TITLE
fix containers cascading restart by adding a cooldown period

### DIFF
--- a/internal/discovery/compose.go
+++ b/internal/discovery/compose.go
@@ -1,3 +1,5 @@
+// Package discovery provides compose path resolution from environment variables
+// and builds the parent-to-dependents map from root-level depends_on.
 package discovery
 
 import (
@@ -12,18 +14,22 @@ import (
 // ComposeFile represents the minimal structure needed to read root-level depends_on.
 // Only "services" and each service's "depends_on" are used.
 type ComposeFile struct {
+	// Services maps service name to service definition.
 	Services map[string]ComposeService `yaml:"services"`
 }
 
 // ComposeService holds a single service's depends_on (and optional fields we ignore).
 type ComposeService struct {
-	DependsOn interface{} `yaml:"depends_on"` // short: []string, long: map[string]DependsOnEntry
+	// DependsOn is short form ([]string) or long form (map[string]DependsOnEntry).
+	DependsOn interface{} `yaml:"depends_on"`
 }
 
 // DependsOnEntry is the long-form value (condition, restart, etc.).
 type DependsOnEntry struct {
+	// Condition is the dependency condition (e.g. service_started).
 	Condition string `yaml:"condition"`
-	Restart   *bool  `yaml:"restart"`
+	// Restart is optional; when set, controls restart behavior.
+	Restart *bool `yaml:"restart"`
 }
 
 // ParseComposeFile reads and parses a compose YAML file into ComposeFile.

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -17,10 +17,14 @@ type Client struct {
 
 // ContainerInfo holds minimal container data for discovery.
 type ContainerInfo struct {
-	ID     string
-	Name   string
+	// ID is the container ID.
+	ID string
+	// Name is the container name (without leading slash).
+	Name string
+	// Labels holds container labels (e.g. com.docker.compose.service).
 	Labels map[string]string
-	State  string // "running", "exited", etc.; only set when ListContainers is called with all=true
+	// State is "running", "exited", etc.; only set when ListContainers is called with all=true.
+	State string
 }
 
 // NewClient creates a Docker client using DOCKER_HOST (default unix socket).

--- a/internal/docker/events.go
+++ b/internal/docker/events.go
@@ -1,3 +1,5 @@
+// Package docker provides a Docker API client for listing containers, inspecting
+// health status, and restarting containers, plus logging and health-status event subscription.
 package docker
 
 import (
@@ -9,9 +11,12 @@ import (
 
 // HealthEvent is emitted when a container's health status changes.
 type HealthEvent struct {
-	ContainerID   string
+	// ContainerID is the container ID.
+	ContainerID string
+	// ContainerName is the container name.
 	ContainerName string
-	Status        string // "health_status: unhealthy" etc.
+	// Status is the event action (e.g. "health_status: unhealthy").
+	Status string
 }
 
 // SubscribeHealthStatus subscribes to Docker container events: health_status (unhealthy), die, and stop.

--- a/internal/docker/log.go
+++ b/internal/docker/log.go
@@ -1,3 +1,5 @@
+// Package docker provides a Docker API client for listing containers, inspecting
+// health status, and restarting containers, plus logging and health-status event subscription.
 package docker
 
 import (

--- a/internal/recovery/restart.go
+++ b/internal/recovery/restart.go
@@ -15,6 +15,7 @@ const defaultWaitHealthyTimeout = 5 * time.Minute
 
 // Flow runs the full recovery sequence: restart parent, wait until healthy, restart dependents.
 type Flow struct {
+	// Client is the Docker client used for restart and inspect.
 	Client *docker.Client
 }
 


### PR DESCRIPTION
- fix(core): restart cooldowns (`5d8fc04`)
- fix(core): Validate RECOVERY_COOLDOWN is positive and log when recovery is skipped due to cooldown (`a9a692f`)
- fix(core): fixed some code smells, updated docstring (`2b7c285`)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented a per-parent recovery cooldown to throttle recovery attempts and reduce repeated recoveries.
  * Cooldown duration is configurable via RECOVERY_COOLDOWN (defaults to 2 minutes).
  * Cooldown is enforced across startup and polling recovery paths; skipped recoveries emit debug logs for visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->